### PR TITLE
fix: small ui changes

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -271,7 +271,7 @@ text-area {
 
 .mdc-card {
   margin-bottom: 5px;
-  padding: 16px;
+  padding: 8px;
   @include mat.elevation(1);
 }
 
@@ -510,6 +510,7 @@ textarea {
 
 .small-button {
   line-height: 32px;
+  text-wrap: nowrap;
 
   .mat-icon {
     font-size: 16px;


### PR DESCRIPTION
## Description:

2 minor changes in the ui - under the styles.scss file.

1. change mdc card padding to 8px:
before:
<img width="320" alt="image" src="https://github.com/user-attachments/assets/b5b51208-3bf9-4bf8-9c4e-2b3f8b77b886">

after:
<img width="322" alt="image" src="https://github.com/user-attachments/assets/2f0d37b0-ccf7-430d-a0be-ffe7db29e5a1">


3. change small-button text-wrap to no wrap
before:
<img width="333" alt="image" src="https://github.com/user-attachments/assets/2e1556ca-2968-458e-94af-394a4058bcd4">

after:
<img width="323" alt="image" src="https://github.com/user-attachments/assets/79804b3e-34b6-437e-8866-4a81e19fe52e">

