### PR TITLE
fix: adjusted print-volunteers to fit A4

### DIFF
--- a/src/app/print-volunteers/print-volunteers.component.html
+++ b/src/app/print-volunteers/print-volunteers.component.html
@@ -1,14 +1,26 @@
-<table class="printTable">
-  <tr>
-    <th>מתנדבים</th>
-    <th>כמות</th>
-  </tr>
-  <tr *ngFor="let v of volunteers">
-    <td>{{ v.name }}</td>
-    <td>{{ v.quantity }}</td>
-  </tr>
-  <tr>
-    <th>סה"כ</th>
-    <th>{{ total }}</th>
-  </tr>
-</table>
+<div class="printTableContainer">
+  <div class="printColumn">
+    <table class="printTable">
+      <tr>
+        <th>מתנדבים</th>
+        <th>כמות</th>
+      </tr>
+      <tr *ngFor="let v of volunteers | slice: 0:volunteers.length / 2">
+        <td>{{ v.name }}</td>
+        <td>{{ v.quantity }}</td>
+      </tr>
+    </table>
+  </div>
+  <div class="printColumn">
+    <table class="printTable">
+      <tr>
+        <th>מתנדבים</th>
+        <th>כמות</th>
+      </tr>
+      <tr *ngFor="let v of volunteers | slice: volunteers.length / 2">
+        <td>{{ v.name }}</td>
+        <td>{{ v.quantity }}</td>
+      </tr>
+    </table>
+  </div>
+</div>

--- a/src/app/print-volunteers/print-volunteers.component.scss
+++ b/src/app/print-volunteers/print-volunteers.component.scss
@@ -1,14 +1,38 @@
+.printTableContainer {
+  display: flex;
+  justify-content: space-between;
+}
+
+.printColumn {
+  width: 48%;
+}
+
 .printTable {
   -webkit-print-color-adjust: exact;
-
   font-size: smaller;
+  border-collapse: collapse;
+  width: 100%;
+
   th,
   td {
     border: 1px solid #ddd !important;
     padding-left: 8px !important;
     padding-right: 8px !important;
+    word-break: break-word;
   }
+
   tr:nth-child(even) {
     background-color: rgba(0, 0, 0, 0.05) !important;
+  }
+}
+
+@media print {
+  .printTableContainer {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .printColumn {
+    width: 48%;
   }
 }


### PR DESCRIPTION
## Description

This update enhances the layout of the volunteer list when printed. The table is now split into two columns, optimizing the use of space on an A4 page, ensuring the list fits neatly within a single page and is easier to read.

Here is a preview for the new printing page:

<img width="537" alt="image" src="https://github.com/user-attachments/assets/0551e123-6907-488c-ad90-939fd9833ea9">
