### PR TITLE
UI improvements

### DIFF
--- a/src/app/date-range/date-range.component.html
+++ b/src/app/date-range/date-range.component.html
@@ -1,4 +1,6 @@
-<div style="margin-bottom: 15px">
+<div
+  style="margin-bottom: 10px; display: flex; justify-content: center; gap: 10px"
+>
   <button mat-raised-button (click)="previous()">
     <mat-icon>keyboard_arrow_right</mat-icon>
   </button>
@@ -8,15 +10,15 @@
   <button mat-raised-button (click)="next()">
     <mat-icon>keyboard_arrow_left</mat-icon>
   </button>
-</div>
-<div style="display: flex; align-content: flex-end">
-  <data-area [settings]="rangeArea"></data-area>
   <button
     mat-mini-fab
-    style="margin: 15px"
+    style="margin: 0px"
     (click)="dateChanged.emit()"
     color="primary"
   >
     <mat-icon>refresh</mat-icon>
   </button>
+</div>
+<div style="display: flex; align-content: flex-end">
+  <data-area [settings]="rangeArea"></data-area>
 </div>

--- a/src/app/distribution-map/distribution-map.component.html
+++ b/src/app/distribution-map/distribution-map.component.html
@@ -65,7 +65,7 @@
   <div>
     <button
       mat-mini-fab
-      style="margin-bottom: 5px"
+      style="margin: 5px"
       (click)="refreshDeliveries()"
       color="primary"
     >

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -252,13 +252,16 @@ text-area {
 .one-line {
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 .one-line>* {
   padding-left: 0.2em;
   padding-right: 0.2em;
-  flex-basis: 1px;
+  flex-basis: auto;
   flex-grow: 1;
+  min-width: 0;
 }
 
 .one-line> :first-child {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -214,7 +214,7 @@ text-area {
 }
 
 .mat-expansion-panel-header {
-  padding-left: 2px !important;
+  padding-left: 10px !important;
   padding-right: 2px !important;
 }
 


### PR DESCRIPTION
1. fix overflow of date pickers and referesh buttons in delivery history
before:
<img width="314" alt="Screenshot 2024-08-27 at 0 16 13" src="https://github.com/user-attachments/assets/997e0cac-4bfd-40a6-b342-d0e87846326c">
after:
<img width="310" alt="Screenshot 2024-08-27 at 0 16 41" src="https://github.com/user-attachments/assets/3087f24c-9a4f-4333-b61a-4cb6d5b64f9f">

2. fix overflow date picker:

after:

<img width="402" alt="Screenshot 2024-08-27 at 14 49 49" src="https://github.com/user-attachments/assets/710005b3-4f20-44de-96f6-c7ee71057e31">

3. add margin to buttons in distribution map:
before:

<img width="404" alt="Screenshot 2024-08-27 at 15 06 53" src="https://github.com/user-attachments/assets/23346c28-d276-470b-aba6-94f631e09ccd">

after:

![Screenshot 2024-08-27 at 15 15 34](https://github.com/user-attachments/assets/bcbf556f-5413-4fb6-a65c-2ac22b89645d)
